### PR TITLE
chore: bump terraform required version and drop patch version pinning

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.31"
 
   required_providers {
     azuread = ">= 0.11"
@@ -7,7 +7,7 @@ terraform {
     random  = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.2.0"
+      version = "~> 0.3"
     }
   }
 }


### PR DESCRIPTION
This PR bumps the required_version of Terraform to 0.12.31 to address [HCSEC-2021-12](https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570), and removes pinning on patch changes to pessimistic pinning on minor changes. 


Signed-off-by: Scott Ford <scott.ford@lacework.net>