### PR TITLE
chore: pessimistic version pinning on minor releases of dependent modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
 
 module "az_cfg_ad_application" {
   source                      = "lacework/ad-application/azure"
-  version                     = "~> 0.1.0"
+  version                     = "~> 0.1"
   create                      = var.use_existing_ad_application ? false : true
   application_name            = var.application_name
   application_identifier_uris = var.application_identifier_uris


### PR DESCRIPTION
This PR fixes version pinning on dependent modules so we pessimistically pin to minor releases instead of patch releases. 

Signed-off-by: Scott Ford <scott.ford@lacework.net>