### PR TITLE
feat: allow the use of management groups to assign permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Local .terraform directories
-**/.terraform/*
+**/.terraform*
 
 # .tfstate files
 *.tfstate

--- a/README.md
+++ b/README.md
@@ -3,6 +3,34 @@
 # terraform-azure-config
 
 [![GitHub release](https://img.shields.io/github/release/lacework/terraform-azure-config.svg)](https://github.com/lacework/terraform-azure-config/releases/)
-[![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/lacework/terraform-modules%2Ftest-compatibility?type=cf-1&key=eyJhbGciOiJIUzI1NiJ9.NWVmNTAxOGU4Y2FjOGQzYTkxYjg3ZDEx.RJ3DEzWmBXrJX7m38iExJ_ntGv4_Ip8VTa-an8gBwBo)]( https://g.codefresh.io/pipelines/edit/new/builds?id=607e25e6728f5a6fba30431b&pipeline=test-compatibility&projects=terraform-modules&projectId=607db54b728f5a5f8930405d)
+[![Codefresh build status](https://g.codefresh.io/api/badges/pipeline/lacework/terraform-modules%2Ftest-compatibility?type=cf-1&key=eyJhbGciOiJIUzI1NiJ9.NWVmNTAxOGU4Y2FjOGQzYTkxYjg3ZDEx.RJ3DEzWmBXrJX7m38iExJ_ntGv4_Ip8VTa-an8gBwBo)](https://g.codefresh.io/pipelines/edit/new/builds?id=607e25e6728f5a6fba30431b&pipeline=test-compatibility&projects=terraform-modules&projectId=607db54b728f5a5f8930405d)
 
 Terraform module for integrating Azure Subscriptions and Tenants with Lacework for cloud resource configuration assessment.
+
+## Inputs
+
+| Name                        | Description                                                                                                      | Type           | Default                     | Required |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------------- | --------------------------- | :------: |
+| all_subscriptions           | If set to true, grant read access to ALL subscriptions within the selected Tenant (overrides 'subscription_ids') | `bool`         | `false`                     |    no    |
+| application_id              | The Active Directory Application id to use (required when use_existing_ad_application is set to true)            | `string`       | `""`                        |    no    |
+| application_identifier_uris | A list of user-defined URI(s) for the Lacework AD Application                                                    | `list(string)` | `[]`                        |    no    |
+| application_name            | The name of the Azure Active Directory Applicaiton                                                               | `string`       | `"lacework_security_audit"` |    no    |
+| application_password        | The Active Directory Application password to use (required when use_existing_ad_application is set to true)      | `string`       | `""`                        |    no    |
+| key_vault_ids               | A list of Key Vault Ids used in your subscription for the Lacework AD App to have access to                      | `list(string)` | `[]`                        |    no    |
+| lacework_integration_name   | The Lacework integration name                                                                                    | `string`       | `"TF config"`               |    no    |
+| management_group_id         | The ID of the Management Group                                                                                   | `string`       | `""`                        |    no    |
+| password_length             | The length of the Lacework AD Application password                                                               | `number`       | `30`                        |    no    |
+| subscription_ids            | List of subscriptions to grant read access to, by default the module will only use the primary subscription      | `list(string)` | `[]`                        |    no    |
+| tenant_id                   | A Tenant ID different from the default defined inside the provider                                               | `string`       | `""`                        |    no    |
+| use_existing_ad_application | Set this to true to use an existing Active Directory Application                                                 | `bool`         | `false`                     |    no    |
+| use_management_group        | If set to `true`, the AD Application will be set up to leverage a Management Group                               | `bool`         | `false`                     |    no    |
+| wait_time                   | Amount of time to wait before the Lacework resources are provisioned                                             | `string`       | `"10s"`                     |    no    |
+
+## Outputs
+
+| Name                 | Description                                      |
+| -------------------- | ------------------------------------------------ |
+| application_id       | The Lacework AD Application id                   |
+| application_password | The Lacework AD Application password             |
+| service_principal_id | The Lacework Service Principal id                |
+| tenant_id            | A Tenant ID used to configure the AD Application |

--- a/examples/custom-config/README.md
+++ b/examples/custom-config/README.md
@@ -1,5 +1,9 @@
 # Customized Integration of Azure with Lacework for Configuration Assessment
+
 The following example shows how to integrate an Azure Tenant and select subscriptions with Lacework for configuration assessment.
+
+## Sample Code
+
 ```hcl
 terraform {
   required_providers {
@@ -19,7 +23,7 @@ provider "lacework" {}
 
 module "az_config" {
   source                      = "lacework/config/azure"
-  version                     = "~> 0.1.2"
+  version                     = "~> 0.1"
   application_name            = "lacework_custom_ad_application_name"
   application_identifier_uris = ["https://account.lacework.net"]
   subscription_ids            = ["subscription-id-1", "subscription-id-2", "subscription-id-3"]

--- a/examples/default-config/README.md
+++ b/examples/default-config/README.md
@@ -1,5 +1,8 @@
 # Default Integration of Azure with Lacework for Configuration Assessment
+
 The following example shows a default integration of an Azure Tenant and the default subscription with Lacework for configuration assessment.
+
+## Sample Code
 
 ```hcl
 terraform {
@@ -20,7 +23,7 @@ provider "lacework" {}
 
 module "az_config" {
   source  = "lacework/config/azure"
-  version = "~> 0.1.2"
+  version = "~> 0.1"
 }
 ```
 

--- a/examples/management-group/README.md
+++ b/examples/management-group/README.md
@@ -1,0 +1,32 @@
+# Integration of Azure with Lacework for Configuration Assessment w/ Management Group
+
+The following example shows a default integration of an Azure Tenant and the default subscription with Lacework for configuration assessment using a Management Group.
+
+## Sample Code
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "azuread" {}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "lacework" {}
+
+module "az_config" {
+  source               = "lacework/config/azure"
+  version              = "~> 0.1"
+  use_management_group = true
+  management_group_id  = "e4ef0585-9741-419d-a121-5886972c85d0"
+}
+```
+
+For detailed information on integrating Lacework with Azure see [Azure Compliance & Activity Log Integrations - Terraform From Any Supported Host](https://support.lacework.com/hc/en-us/articles/360058966313-Azure-Compliance-Activity-Log-Integrations-Terraform-From-Any-Supported-Host)

--- a/examples/management-group/main.tf
+++ b/examples/management-group/main.tf
@@ -1,0 +1,11 @@
+provider "azuread" {}
+
+provider "azurerm" {
+  features {}
+}
+
+module "ad_application" {
+  source               = "../../"
+  use_management_group = true
+  management_group_id  = "e4ef0585-9741-419d-a121-5886972c85d0"
+}

--- a/examples/management-group/versions.tf
+++ b/examples/management-group/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,8 @@ module "az_cfg_ad_application" {
   key_vault_ids               = var.key_vault_ids
   tenant_id                   = var.tenant_id
   password_length             = var.password_length
+  use_management_group        = var.use_management_group
+  management_group_id         = var.management_group_id
 }
 
 # wait for X seconds for the Azure resources to be created

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -9,8 +9,9 @@ set -eou pipefail
 readonly project_name=terraform-azure-config
 
 TEST_CASES=(
-  examples/custom-config/
-  examples/default-config/
+  examples/custom-config
+  examples/default-config
+  examples/management-group
 )
 
 log() {

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,15 @@ variable "application_password" {
   default     = ""
   description = "The Active Directory Application password to use (required when use_existing_ad_application is set to true)"
 }
+
+variable "use_management_group" {
+  type        = bool
+  default     = false
+  description = "If set to `true`, the AD Application will be set up to leverage a Management Group"
+}
+
+variable "management_group_id" {
+  type        = string
+  default     = ""
+  description = "The ID of the Management Group"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.31"
 
   required_providers {
-    azuread = ">= 0.11"
+    azuread = "~> 1.2"
     azurerm = "~> 2.26"
     lacework = {
       source  = "lacework/lacework"

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,7 @@ terraform {
 
   required_providers {
     azuread = ">= 0.11"
-    azurerm = "~> 2.26.0"
-    random  = ">= 2.1"
+    azurerm = "~> 2.26"
     lacework = {
       source  = "lacework/lacework"
       version = "~> 0.3"


### PR DESCRIPTION
This is still pending the Terraform Registry updating the `ad-application` module, but I wanted to get this in before the weekend.  We should see `v0.2.0` here: https://registry.terraform.io/modules/lacework/ad-application/azure/latest

Once that's completed, the CI tests should run successfully for this PR.