### PR TITLE
refactor: increase wait timer to 20s

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Terraform module for integrating Azure Subscriptions and Tenants with Lacework f
 | tenant_id                   | A Tenant ID different from the default defined inside the provider                                               | `string`       | `""`                        |    no    |
 | use_existing_ad_application | Set this to true to use an existing Active Directory Application                                                 | `bool`         | `false`                     |    no    |
 | use_management_group        | If set to `true`, the AD Application will be set up to leverage a Management Group                               | `bool`         | `false`                     |    no    |
-| wait_time                   | Amount of time to wait before the Lacework resources are provisioned                                             | `string`       | `"10s"`                     |    no    |
+| wait_time                   | Amount of time to wait before the Lacework resources are provisioned                                             | `string`       | `"20s"`                     |    no    |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "lacework_integration_name" {
 
 variable "wait_time" {
   type        = string
-  default     = "10s"
+  default     = "20s"
   description = "Amount of time to wait before the Lacework resources are provisioned"
 }
 


### PR DESCRIPTION
---
name: Increase timer waiting for azure resources to be created
about: fixing bug #21
---

Closes https://github.com/lacework/terraform-azure-config/issues/21

***Description:***
Nearly half of the issues I help troubleshoot concern Lacework integration API returning 400 error (for the config) or "Unable to locate storage account" (for activity log). This can be prevented by increasing the time between requesting the azure resource and instructing Lacework to try reading them.

I suggest 20 seconds default

