### PR TITLE
refactor: remove unneeded version pin for azuread

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_version = ">= 0.12.31"
 
   required_providers {
-    azuread = "~> 1.2"
     azurerm = "~> 2.28"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
The submodule terraform-azure-ad-application provides its own version pin, which will be 2.x soon. We need to remove this unnecesary pin here because it's unused yet it blocks the AD app to use 2.x if needed.
