### PR TITLE
fix: Avoid 400 Error in upgrade scenario

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,9 +48,9 @@ resource "time_sleep" "wait_time" {
   create_duration = var.wait_time
   depends_on      = [azurerm_role_assignment.grant_reader_role_to_subscriptions]
   triggers = {
-    # Save the time we first heard about the application ID, so we wait again if it changes
+    # If App ID changes, trigger a wait between lacework_integration_azure_cfg destroys and re-creates, to avoid API errors
     app_id = local.application_id
-    # Same thing for LW integration name, which changed for v1.0, and waiting is needed to avoid API error when recreating it too fast
+    # If the Integration object changes (like during upgrade to v1.0), trigger a wait between lacework_integration_azure_cfg destroys and re-creates, to avoid API errors
     integration_name = var.lacework_integration_name
   }
 


### PR DESCRIPTION
Without these extra Triggers in the wait_time module, during an upgrade, the lacework config deletes and creates the integration too quickly, so the creation fails with 400 error. When tried again, TF config worked fine.

```
╷
│ Error: Error creating AZURE_AL_SEQ integration:
│   [POST] https://lwintmarcgarcia.lacework.net/api/v1/external/integrations
│   [400] Unable to validate the Azure integration, verify your configuration and queue url.
│
│   with module.az_activity_log.lacework_integration_azure_al.lacework,
│   on .terraform/modules/az_activity_log/main.tf line 182, in resource "lacework_integration_azure_al" "lacework":
│  182: resource "lacework_integration_azure_al" "lacework" {
│
```

Adding these triggers will avoid that issue during upgrade to v1.0