### PR TITLE
chore: update Lacework provider version to v1

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
     azurerm = "~> 2.28"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.3"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
set version of terraform-provider-lacework to 1.0.0

[_Created by Sourcegraph batch change `darren.murray/terraform-provider-updater`._](https://lacework.sourcegraph.com/users/darren.murray/batch-changes/terraform-provider-updater)