### PR TITLE
feat: added KeyVaultReader role to the Lacework service principal

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ It adds a Service Principal as a subscription "Reader" and "Key Vault Reader", t
 
 | Name | Type |
 |------|------|
+| [azurerm_role_assignment.grant_key_vault_reader_role_to_managementgroup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.grant_key_vault_reader_role_to_subscriptions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.grant_reader_role_to_managementgroup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.grant_reader_role_to_subscriptions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [lacework_integration_azure_cfg.lacework](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/integration_azure_cfg) | resource |

--- a/main.tf
+++ b/main.tf
@@ -25,10 +25,18 @@ data "azurerm_subscriptions" "available" {}
 
 resource "azurerm_role_assignment" "grant_reader_role_to_subscriptions" {
   count = length(local.subscription_ids)
-  scope = "/subscriptions/${local.subscription_ids[count.index]}"
 
+  scope                = "/subscriptions/${local.subscription_ids[count.index]}"
   principal_id         = local.service_principal_id
   role_definition_name = "Reader"
+}
+
+resource "azurerm_role_assignment" "grant_key_vault_reader_role_to_subscriptions" {
+  count = length(local.subscription_ids)
+
+  scope                = "/subscriptions/${local.subscription_ids[count.index]}"
+  principal_id         = local.service_principal_id
+  role_definition_name = "Key Vault Reader"
 }
 
 data "azurerm_management_group" "managementgroup" {
@@ -37,10 +45,19 @@ data "azurerm_management_group" "managementgroup" {
 }
 
 resource "azurerm_role_assignment" "grant_reader_role_to_managementgroup" {
-  count                = var.use_management_group ? 1 : 0
+  count = var.use_management_group ? 1 : 0
+
   scope                = data.azurerm_management_group.managementgroup[0].id
   principal_id         = local.service_principal_id
   role_definition_name = "Reader"
+}
+
+resource "azurerm_role_assignment" "grant_key_vault_reader_role_to_managementgroup" {
+  count = var.use_management_group ? 1 : 0
+
+  scope                = data.azurerm_management_group.managementgroup[0].id
+  principal_id         = local.service_principal_id
+  role_definition_name = "Key Vault Reader"
 }
 
 # wait for X seconds for the Azure permissions to propagate


### PR DESCRIPTION
## Summary

Adding `KeyVaultReader` role to the Lacework service principal.

## How did you test this change?

Deployed the module and validated that the role was applied at both the subscription and management group level.

## Issue

[GROW-1323](https://lacework.atlassian.net/browse/GROW-1323)


[GROW-1323]: https://lacework.atlassian.net/browse/GROW-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ