### PR TITLE
fix: docs links and add wait_time override example

### DIFF
--- a/examples/custom-config/README.md
+++ b/examples/custom-config/README.md
@@ -29,4 +29,4 @@ module "az_config" {
 }
 ```
 
-For detailed information on integrating Lacework with Azure see [Azure Compliance & Activity Log Integrations - Terraform From Any Supported Host](https://support.lacework.com/hc/en-us/articles/360058966313-Azure-Compliance-Activity-Log-Integrations-Terraform-From-Any-Supported-Host)
+For detailed information on integrating Lacework with Azure see [Azure Compliance & Activity Log Integrations - Terraform From Any Supported Host](https://docs.lacework.net/onboarding/azure-compliance-and-activity-log-integrations-terraform-from-any-supported-host)

--- a/examples/custom-config/main.tf
+++ b/examples/custom-config/main.tf
@@ -10,4 +10,5 @@ module "az_config" {
   application_name          = "lacework_custom_ad_application_name"
   subscription_ids          = ["subscription-id-1", "subscription-id-2", "subscription-id-3"]
   lacework_integration_name = "a custom name"
+  wait_time                 = "60s"
 }

--- a/examples/default-config/README.md
+++ b/examples/default-config/README.md
@@ -25,4 +25,4 @@ module "az_config" {
 }
 ```
 
-For detailed information on integrating Lacework with Azure see [Azure Compliance & Activity Log Integrations - Terraform From Any Supported Host](https://support.lacework.com/hc/en-us/articles/360058966313-Azure-Compliance-Activity-Log-Integrations-Terraform-From-Any-Supported-Host)
+For detailed information on integrating Lacework with Azure see [Azure Compliance & Activity Log Integrations - Terraform From Any Supported Host](https://docs.lacework.net/onboarding/azure-compliance-and-activity-log-integrations-terraform-from-any-supported-host)

--- a/examples/management-group/README.md
+++ b/examples/management-group/README.md
@@ -28,4 +28,4 @@ module "az_config" {
 }
 ```
 
-For detailed information on integrating Lacework with Azure see [Azure Compliance & Activity Log Integrations - Terraform From Any Supported Host](https://support.lacework.com/hc/en-us/articles/360058966313-Azure-Compliance-Activity-Log-Integrations-Terraform-From-Any-Supported-Host)
+For detailed information on integrating Lacework with Azure see [Azure Compliance & Activity Log Integrations - Terraform From Any Supported Host](https://docs.lacework.net/onboarding/azure-compliance-and-activity-log-integrations-terraform-from-any-supported-host)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-azure-config/blob/main/CONTRIBUTING.md
--->

## Summary

Fix broken documentation link in the example readmes; add wait_time to the custom example as a means to address timeout issues.


## How did you test this change?

Local test; adding time_wait overrides the default:

```
  # module.az_config.time_sleep.wait_time will be updated in-place
  ~ resource "time_sleep" "wait_time" {
      ~ create_duration = "20s" -> "100s"
        id              = "2023-08-31T14:49:09Z"
        # (1 unchanged attribute hidden)
```

## Issue

https://lacework.atlassian.net/browse/LINK-2400