### PR TITLE
chore: add subscription_id to examples

### DIFF
--- a/examples/custom-config/README.md
+++ b/examples/custom-config/README.md
@@ -14,6 +14,7 @@ terraform {
 }
 
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/custom-config/main.tf
+++ b/examples/custom-config/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/default-config/README.md
+++ b/examples/default-config/README.md
@@ -14,6 +14,7 @@ terraform {
 }
 
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/default-config/main.tf
+++ b/examples/default-config/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/management-group/README.md
+++ b/examples/management-group/README.md
@@ -14,6 +14,7 @@ terraform {
 }
 
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 

--- a/examples/management-group/main.tf
+++ b/examples/management-group/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000001"
   features {}
 }
 


### PR DESCRIPTION
## Summary

`subscription_id` is required as of azurerm 4.0